### PR TITLE
Add a console by default

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -6,6 +6,8 @@ let
     modules = [ {
       fileSystems."/".device = "/dev/disk/by-label/nixos";
 
+      boot.kernelParams = [ "earlycon=ttyS0" "console=ttyS0" ];
+
       boot.loader.grub.version = 2;
       boot.loader.grub.device = "/dev/sda";
       boot.loader.timeout = 0;


### PR DESCRIPTION
Helps debugging startup issues.

I am trying to debug some issues with different kernels and bus access and this is useful to see errors during startup.