### PR TITLE
Update trivial-virtd.nix: Include network.description

### DIFF
--- a/examples/trivial-virtd.nix
+++ b/examples/trivial-virtd.nix
@@ -1,4 +1,5 @@
 {
+  network.description = "Example Machine";
   machine =
     { deployment.targetEnv = "libvirtd";
       deployment.libvirtd.imageDir = "/var/lib/libvirt/images";


### PR DESCRIPTION
Include network.description, otherwise deploying example file will fail with NixOps unstable.